### PR TITLE
Fix/frontend/criticals

### DIFF
--- a/webapp/src/css/Leaderboard.css
+++ b/webapp/src/css/Leaderboard.css
@@ -22,7 +22,7 @@
     width: 80%;
     max-height: 44rem;      /* 4 rem per list item (10 items max.) + 4rem (margins and dividers) */
     height: auto;
-    overflow-y: auto;
+    text-overflow: ellipsis;
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
     transition: transform 0.2s, box-shadow 0.2s;
 }

--- a/webapp/src/css/Statistics.css
+++ b/webapp/src/css/Statistics.css
@@ -63,3 +63,7 @@
 .recharts-surface {
     width: 100%;
 }
+
+.recharts-wrapper {
+    overflow: visible;
+}

--- a/webapp/src/windows/Leaderboard.jsx
+++ b/webapp/src/windows/Leaderboard.jsx
@@ -94,7 +94,11 @@ const Leaderboard = () => {
                     >
                       <ListItemText 
                         primary={`${index + 1}. ${result.userId} ${result.userId?.toString() === loggedInPlayerId?.toString() ? '(You)' : ''}`}
-                        secondary={`${t('score')}: ${result.score}`} 
+                        secondary={`${t('score')}: ${result.score}`}
+                        primaryTypographyProps={{
+                          noWrap: true,
+                          style: { maxWidth: "18ch" }
+                        }}
                       />
                     </ListItem>
                     {index < results.length - 1 && <Divider />}

--- a/webapp/src/windows/Statistics.jsx
+++ b/webapp/src/windows/Statistics.jsx
@@ -292,15 +292,14 @@ const Statistics = () => {
                       {t("statistics.answerDistribution")}
                     </Typography>
                     <ResponsiveContainer width="100%" height={300}>
-                      <PieChart
-                        padding={5}
-                      >
+                      <PieChart>
                         <Pie
                           data={pieChartData}
                           cx="50%"
                           cy="50%"
                           labelLine={false}
-                          outerRadius={100}
+                          outerRadius={80}
+                          paddingAngle={5}
                           fill="#8884d8"
                           dataKey="value"
                           label={({ name, percent }) =>


### PR DESCRIPTION
Critical error solvings: Long names are no longer an issue in the leaderboard (They get enshortened by an ellipsis when they are over 18 characters).

PieChart diagram now is a bit smaller and has more space for the texts, so they should be more visible